### PR TITLE
Replace constants being deprecated in 2026.1

### DIFF
--- a/custom_components/vesync/light.py
+++ b/custom_components/vesync/light.py
@@ -4,9 +4,8 @@ import logging
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
-    COLOR_MODE_BRIGHTNESS,
-    COLOR_MODE_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
+    ColorMode,
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -103,9 +102,9 @@ class VeSyncBaseLight(VeSyncDevice, LightEntity):
         """Turn the device on."""
         attribute_adjustment_only = False
         # set white temperature
-        if self.color_mode in (COLOR_MODE_COLOR_TEMP,) and ATTR_COLOR_TEMP in kwargs:
+        if self.color_mode in (ColorMode.COLOR_TEMP,) and ATTR_COLOR_TEMP_KELVIN in kwargs:
             # get white temperature from HA data
-            color_temp = int(kwargs[ATTR_COLOR_TEMP])
+            color_temp = int(kwargs[ATTR_COLOR_TEMP_KELVIN])
             # ensure value between min-max supported Mireds
             color_temp = max(self.min_mireds, min(color_temp, self.max_mireds))
             # convert Mireds to Percent value that api expects
@@ -123,7 +122,7 @@ class VeSyncBaseLight(VeSyncDevice, LightEntity):
             attribute_adjustment_only = True
         # set brightness level
         if (
-            self.color_mode in (COLOR_MODE_BRIGHTNESS, COLOR_MODE_COLOR_TEMP)
+            self.color_mode in (ColorMode.BRIGHTNESS, ColorMode.COLOR_TEMP)
             and ATTR_BRIGHTNESS in kwargs
         ):
             # get brightness from HA data
@@ -148,12 +147,12 @@ class VeSyncDimmableLightHA(VeSyncBaseLight, LightEntity):
     @property
     def color_mode(self):
         """Set color mode for this entity."""
-        return COLOR_MODE_BRIGHTNESS
+        return ColorMode.BRIGHTNESS
 
     @property
     def supported_color_modes(self):
         """Flag supported color_modes (in an array format)."""
-        return [COLOR_MODE_BRIGHTNESS]
+        return [ColorMode.BRIGHTNESS]
 
 
 class VeSyncTunableWhiteLightHA(VeSyncBaseLight, LightEntity):
@@ -203,12 +202,12 @@ class VeSyncTunableWhiteLightHA(VeSyncBaseLight, LightEntity):
     @property
     def color_mode(self):
         """Set color mode for this entity."""
-        return COLOR_MODE_COLOR_TEMP
+        return ColorMode.COLOR_TEMP
 
     @property
     def supported_color_modes(self):
         """Flag supported color_modes (in an array format)."""
-        return [COLOR_MODE_COLOR_TEMP]
+        return [ColorMode.COLOR_TEMP]
 
 
 class VeSyncNightLightHA(VeSyncDimmableLightHA):

--- a/custom_components/vesync/light.py
+++ b/custom_components/vesync/light.py
@@ -102,7 +102,10 @@ class VeSyncBaseLight(VeSyncDevice, LightEntity):
         """Turn the device on."""
         attribute_adjustment_only = False
         # set white temperature
-        if self.color_mode in (ColorMode.COLOR_TEMP,) and ATTR_COLOR_TEMP_KELVIN in kwargs:
+        if (
+            self.color_mode in (ColorMode.COLOR_TEMP,)
+            and ATTR_COLOR_TEMP_KELVIN in kwargs
+        ):
             # get white temperature from HA data
             color_temp = int(kwargs[ATTR_COLOR_TEMP_KELVIN])
             # ensure value between min-max supported Mireds


### PR DESCRIPTION
Replaced some light entity constants, which have been deprecated and will be removed in `2026.1`. This is mainly to just get ahead of it since users will start to see warnings in their logs starting with HA `2025.1`.

![image](https://github.com/user-attachments/assets/53eecac8-cf68-4625-ad24-0831d23a685c)
