### PR TITLE
Update config_flow.py for deprecated constant #51 (DhcpServiceInfo)

### DIFF
--- a/custom_components/vesync/config_flow.py
+++ b/custom_components/vesync/config_flow.py
@@ -9,7 +9,7 @@ from typing import Any
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.components import dhcp
+from homeassistant.helpers.service_info import dhcp
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult


### PR DESCRIPTION
Warning msg:  [homeassistant.components.dhcp] DhcpServiceInfo was used from vesync, this is a deprecated constant which will be removed in HA Core 2026.2. Use homeassistant.helpers.service_info.dhcp.DhcpServiceInfo instead, please report it to the author of the 'vesync' custom integration.

changed so uses  correct component.


