### PR TITLE
71: Prevent unneeded auto-discovery of devices when already set up

### DIFF
--- a/custom_components/vesync/config_flow.py
+++ b/custom_components/vesync/config_flow.py
@@ -143,8 +143,12 @@ class VeSyncFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
         """Handle DHCP discovery."""
-        hostname = discovery_info.hostname
+        # VeSync is a cloud account integration — if it's already configured,
+        # DHCP discovery of any Levoit device is a no-op.
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
 
+        hostname = discovery_info.hostname
         _LOGGER.debug("DHCP discovery detected device %s", hostname)
         self.context["title_placeholders"] = {"gateway_id": hostname}
         return await self.async_step_user()


### PR DESCRIPTION
This fixes issue #71 

Since this integration is a cloud-based integration, any new entities added to the cloud integration will be included automatically. The detection of devices using DHCP is meant to be a trigger for the initial setup of cloud integrations. Because new devices will already be detected through the existing integration, it is unnecessary to prompt to set up the integration when DHCP detects a new device. Thus, we can safely ignore newly detected DHCP devices if the integration is already configured, which will prevent the useless "device detected" cards from appearing on the integration screen